### PR TITLE
Fixed error whitout options and added selector option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,16 @@ You then use it like so;
 Metalsmith(__dirnam).use(
     imageLazyLoading({
         pattern: ['**/*.html'],
+        selector: '.article__content',
     })
 );
 ```
 
 That's all there is to it.
+
+### Options
+
+| Key | Description | default |
+|-----|-------------|---------|
+| pattern | Pattern to select files to handle | `**/*.html` |
+| selector | Css selector to refine image replacement. This is appended with ` img:not([loading])` |  |

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function plugin(opts) {
 
     // make sure that the default required options are filled in
     opts.pattern = opts.pattern || '**/*.html';
+    opts.selector = opts.selector || '';
 
     var totalImagesFixed = 0;
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var debug = require('debug')('metalsmith:nativeLazyLoading');
+var debug = require('metalsmith-debug')('metalsmith:nativeLazyLoading');
 var multimatch = require('multimatch');
 var cheerio = require('cheerio');
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var debug = require('metalsmith-debug')('metalsmith:nativeLazyLoading');
+var debug = require('debug')('metalsmith:nativeLazyLoading');
 var multimatch = require('multimatch');
 var cheerio = require('cheerio');
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function plugin(opts) {
                 var $ = cheerio.load(data.contents.toString());
 
                 // Find all images in articles that is missing loading attribute
-                var $imagesWithoutLoadingDefined = $('.article__content img:not([loading])');
+                var $imagesWithoutLoadingDefined = $(opts.selector + ' img:not([loading])');
 
                 // Add loading lazy to all images
                 $imagesWithoutLoadingDefined.attr('loading', 'lazy');

--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ var cheerio = require('cheerio');
 module.exports = plugin;
 
 function plugin(opts) {
+    // check if there are any options passed
+    opts = opts || {};
+
+    // make sure that the default required options are filled in
     opts.pattern = opts.pattern || '**/*.html';
 
     var totalImagesFixed = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-native-lazy-loading",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "A metalsmith plugin for adding browser native lazy loading to images",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixed nullreference error when not providing any options (e.g. using the defaults).

Added option to set the selector used. Before it was hard coded to `.article__content`. I've also updated the readme because there was no mention of this.